### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function collectBucket(node, stack=[]) {
         const key = keys[i];
         const value = node[key];
 
-        if (typeof value === 'object') {
+        if (typeof value === 'object' && value !== null) {
 
             if ("hits" in value && Array.isArray(value.hits) && value.hits.length === 1) {
                 if ("sort" in value.hits[0]) {


### PR DESCRIPTION
Add null value check because typeof (null) is an object and causes the "hits" lookup to fail. Sample output:

```
{
  "took": 11,
  "timed_out": false,
  "_shards": {
    "total": 5,
    "successful": 5,
    "failed": 0
  },
  "hits": {
    "total": 2952,
    "max_score": 0,
    "hits": []
  },
  "aggregations": {
    "2": {
      "buckets": [
        {
          "1": {
            "count": 69,
            "min": 0,
            "max": 9,
            "avg": 2.0652173913043477,
            "sum": 142.5,
            "sum_of_squares": 614.625,
            "variance": 4.642485822306238,
            "std_deviation": 2.1546428526106682,
            "std_deviation_bounds": {
              "upper": 6.374503096525684,
              "lower": -2.244068313916989
            }
          },
          "key_as_string": "20170501T000000.000Z",
          "key": 1493596800000,
          "doc_count": 69
        },
        {
          "1": {
            "count": 70,
            "min": 0,
            "max": 8,
            "avg": 1.9414285714285715,
            "sum": 135.9,
            "sum_of_squares": 489.90999999999997,
            "variance": 3.229569387755101,
            "std_deviation": 1.7971002720369003,
            "std_deviation_bounds": {
              "upper": 5.535629115502372,
              "lower": -1.652771972645229
            }
          },
          "key_as_string": "20170502T000000.000Z",
          "key": 1493683200000,
          "doc_count": 70
        }
      ]
    }
  }
}
```